### PR TITLE
Add holidays in lieu

### DIFF
--- a/js/holidays.js
+++ b/js/holidays.js
@@ -38,8 +38,8 @@ function checkHoliday( year, month, day ) {
 
 		case 'au':
 			holidays = [
-				{ date: calcObservation( year, 1, 1, country ), name: 'New Year\'s Day' },
-				{ date: '1-26', name: 'Australia Day' },
+				...observed( year, 1, 1, country, 'New Year\'s Day' ),
+				...observed( year, 1, 26, country, 'Australia Day' ),
 				{ date: floatingDoW( 1, year, 2, 8 ), name: 'Royal Hobart Regatta (TAS)' },
 				{ date: floatingDoW( 1, year, 3, 1 ), name: 'Labour Day (WA)' },
 				{ date: floatingDoW( 1, year, 3, 8 ), name: 'Labour Day (VIC)' },
@@ -61,8 +61,8 @@ function checkHoliday( year, month, day ) {
 				{ date: floatingDoW( 1, year, 10, 1 ), name: 'Labour Day (ACT, NSW, SA)' },
 				{ date: floatingDoW( 2, year, 11, 1 ), name: 'Melbourne Cup (VIC)' },
 				{ date: floatingDoW( 1, year, 11, 1 ), name: 'Recreation Day (TAS)' },
-				{ date: calcObservation( year, 12, 25, country ), name: 'Christmas Day' },
-				{ date: calcObservation( year, 12, 26, country ), name: 'Boxing Day' }
+				...observed( year, 12, 25, country, 'Christmas Day', { consecutive: 2 } ),
+				...observed( year, 12, 26, country, 'Boxing Day', { consecutive: 2 } )
 			];
 			easterHolidays = [
 				{ days: -2, name: 'Good Friday' },

--- a/js/holidays.js
+++ b/js/holidays.js
@@ -210,8 +210,8 @@ function checkHoliday( year, month, day ) {
 				{ date: floatingDoW( 1, year, 5, 1 ), name: 'May Day Bank Holiday' },
 				{ date: floatingDoW( 1, year, 5, 25 ), name: 'Spring Bank Holiday' },
 				{ date: floatingDoW( 1, year, 8, 25 ), name: 'Late Summer Bank Holiday' },
-				...observed( year, 12, 25, country, 'Christmas Day', { consecutive: 1 } ),
-				...observed( year, 12, 26, country, 'Boxing Day', { consecutive: 1 } )
+				...observed( year, 12, 25, country, 'Christmas Day', { consecutive: 2 } ),
+				...observed( year, 12, 26, country, 'Boxing Day', { consecutive: 2 } )
 			];
 			easterHolidays = [
 				{ days: -2, name: 'Good Friday' },
@@ -366,7 +366,7 @@ function getMonthDays( year ) {
  * @param {string} name Holiday name
  * @param {Object} options Additional options
  * @param {string} options.observedName Holiday name for the observed date
- * @param {number} options.consecutive How many consecutive holidays follow this one (to avoid shifting observed date onto them)
+ * @param {number} options.consecutive How many consecutive holidays is this one a part of (to avoid shifting observed date onto them)
  */
 function observed( year, month, day, country, name, options ) {
 	options = options || {};
@@ -385,9 +385,9 @@ function observed( year, month, day, country, name, options ) {
 
 		case 'au' :
 		case 'uk' :
-			var consecutive = options.consecutive || 0;
+			var consecutive = options.consecutive || 1;
 			if ( dow == 0 )
-				diffs.push( 1 + consecutive );
+				diffs.push( consecutive );
 			else if ( dow == 6 )
 				diffs.push( 2 );
 			break;

--- a/js/holidays.js
+++ b/js/holidays.js
@@ -365,16 +365,16 @@ function getMonthDays( year ) {
  * @param {string} country Country code
  * @param {string} name Holiday name
  * @param {Object} options Additional options
- * @param {string} options.observedName Holiday name for the observed date
  * @param {number} options.consecutive How many consecutive holidays is this one a part of (to avoid shifting observed date onto them)
  * @returns {string} holiday date in 'month-day' format
  */
 function observed( year, month, day, country, name, options ) {
 	options = options || {};
 
-	var diffs = [0],
+	let diffs = [0],
 		date = new Date( year, month - 1, day ),
-		dow = date.getDay();
+		dow = date.getDay(),
+		observedName = name;
 
 	switch ( country ) {
 		case 'mx' :
@@ -391,6 +391,7 @@ function observed( year, month, day, country, name, options ) {
 				diffs.push( consecutive );
 			else if ( dow == 6 )
 				diffs.push( 2 );
+			observedName = `${name} (in lieu)`;
 			break;
 
 		case 'ar' :
@@ -406,23 +407,11 @@ function observed( year, month, day, country, name, options ) {
 			break;
 	}
 
-	var observedName = options.observedName;
-	if ( !observedName ) {
-		switch ( country ) {
-			case 'au':
-				observedName = `Additional public holiday for ${name}`;
-				break;
-			case 'uk':
-				observedName = `${name} (in lieu)`;
-				break;
-		}
-	}
-
 	return diffs.map(diff => {
 		var newDate = dateToMonthDay( dateAdd( date, diff ) );
 		return {
 			date: newDate,
-			name: ( diff == 0 || !observedName ) ? name : observedName
+			name: diff == 0 ? name : observedName
 		}
 	});
 }

--- a/js/holidays.js
+++ b/js/holidays.js
@@ -367,6 +367,7 @@ function getMonthDays( year ) {
  * @param {Object} options Additional options
  * @param {string} options.observedName Holiday name for the observed date
  * @param {number} options.consecutive How many consecutive holidays is this one a part of (to avoid shifting observed date onto them)
+ * @returns {string} holiday date in 'month-day' format
  */
 function observed( year, month, day, country, name, options ) {
 	options = options || {};


### PR DESCRIPTION
 Add, not replace, holidays in lieu; fix consecutive holidays
    
Whenever a holiday falls on a weekend, show both weekend (actual date) and replacement (observed date).
    
Fix consecutive holidays such as Christmas Day and Boxing Day so that observed dates are correct.
    
Tested with Australian and UK holidays. I'm not familiar with the rules in other countries, they might need an update for consistency.

Fixes #7.